### PR TITLE
Fix test failure. Bump stack resolvers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,8 @@ matrix:
     compiler: ": #stack 8.2.2"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack GHCVER=8.4.1 STACK_YAML=stack-8.4.yaml
-    compiler: ": #stack 8.4.1"
+  - env: BUILD=stack GHCVER=8.4.4 STACK_YAML=stack-8.4.yaml
+    compiler: ": #stack 8.4.4"
     addons: {apt: {packages: [libgmp-dev]}}
 
   # Linux/cabal

--- a/examples/re-top.lhs
+++ b/examples/re-top.lhs
@@ -15,7 +15,6 @@ and checkout the 'corrections' branch.
 {-# LANGUAGE RecordWildCards              #-}
 {-# LANGUAGE OverloadedStrings            #-}
 {-# LANGUAGE QuasiQuotes                  #-}
-{-# LANGUAGE CPP                          #-}
 
 module Main(main) where
 
@@ -24,13 +23,9 @@ import           Data.Functor.Identity
 import qualified Data.HashMap.Lazy     as HML
 import qualified Data.List             as L
 import           Data.Maybe
-#if __GLASGOW_HASKELL__ < 804
 import           Data.Monoid hiding ((<>))
-#else
-import           Data.Monoid
-#endif
 import           Data.Ord
-import           Data.Semigroup
+import           Data.Semigroup (Semigroup, (<>))
 import qualified Data.Text             as T
 import qualified Data.Text.IO          as T
 import           Data.Time

--- a/regex.cabal
+++ b/regex.cabal
@@ -177,16 +177,16 @@ Library
     Build-depends:
         array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , hashable             == 1.2.*
       , regex-base           == 0.93.*
       , regex-pcre-builtin   == 0.94.*
       , regex-pcre-text      == 0.94.*
       , regex-tdfa           == 1.2.*
       , regex-tdfa-text      == 1.0.*
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -217,9 +217,9 @@ Executable re-gen-cabals
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
       , regex-tdfa           == 1.2.*
@@ -250,9 +250,9 @@ Test-Suite re-gen-cabals-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
       , regex-tdfa           == 1.2.*
@@ -283,7 +283,7 @@ Executable re-gen-modules
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
@@ -315,7 +315,7 @@ Test-Suite re-gen-modules-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
@@ -346,7 +346,7 @@ Executable re-include
     Build-depends:
         regex                == 1.0.1.3
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , shelly               >= 1.6.1.2
@@ -375,7 +375,7 @@ Test-Suite re-include-test
     Build-depends:
         regex                == 1.0.1.3
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , shelly               >= 1.6.1.2
@@ -405,7 +405,7 @@ Executable re-nginx-log-processor
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -442,7 +442,7 @@ Test-Suite re-nginx-log-processor-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -478,7 +478,7 @@ Executable re-prep
     Build-depends:
         regex                == 1.0.1.3
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -510,7 +510,7 @@ Test-Suite re-prep-test
     Build-depends:
         regex                == 1.0.1.3
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -542,7 +542,7 @@ Executable re-sort-imports
     Build-depends:
         regex                == 1.0.1.3
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -572,7 +572,7 @@ Test-Suite re-sort-imports-test
     Build-depends:
         regex                == 1.0.1.3
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -603,9 +603,9 @@ Executable re-tests
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
       , heredoc              >= 0.2.0.0
@@ -618,7 +618,7 @@ Executable re-tests
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , unordered-containers == 0.2.*
       , utf8-string          >= 1        && < 1.1
@@ -647,9 +647,9 @@ Test-Suite re-tests-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
       , heredoc              >= 0.2.0.0
@@ -662,7 +662,7 @@ Test-Suite re-tests-test
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , unordered-containers == 0.2.*
       , utf8-string          >= 1        && < 1.1
@@ -690,7 +690,7 @@ Executable re-top
     Build-depends:
         regex                == 1.0.1.3
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , blaze-html           >= 0.8.1.0
       , bytestring           == 0.10.*
       , data-default         >= 0.5.3
@@ -726,7 +726,7 @@ Test-Suite re-top-test
     Build-depends:
         regex                == 1.0.1.3
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , blaze-html           >= 0.8.1.0
       , bytestring           == 0.10.*
       , data-default         >= 0.5.3
@@ -764,9 +764,9 @@ Executable re-tutorial
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -779,7 +779,7 @@ Executable re-tutorial
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -811,9 +811,9 @@ Test-Suite re-tutorial-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -826,7 +826,7 @@ Test-Suite re-tutorial-test
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -860,9 +860,9 @@ Test-Suite re-tutorial-os-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -875,7 +875,7 @@ Test-Suite re-tutorial-os-test
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -907,9 +907,9 @@ Executable re-tutorial-options
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -922,7 +922,7 @@ Executable re-tutorial-options
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -954,9 +954,9 @@ Test-Suite re-tutorial-options-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -969,7 +969,7 @@ Test-Suite re-tutorial-options-test
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -1001,9 +1001,9 @@ Executable re-tutorial-replacing
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -1016,7 +1016,7 @@ Executable re-tutorial-replacing
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -1048,9 +1048,9 @@ Test-Suite re-tutorial-replacing-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -1063,7 +1063,7 @@ Test-Suite re-tutorial-replacing-test
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -1095,9 +1095,9 @@ Executable re-tutorial-testbench
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -1110,7 +1110,7 @@ Executable re-tutorial-testbench
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -1142,9 +1142,9 @@ Test-Suite re-tutorial-testbench-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -1157,7 +1157,7 @@ Test-Suite re-tutorial-testbench-test
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -1189,9 +1189,9 @@ Executable re-tutorial-tools
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -1204,7 +1204,7 @@ Executable re-tutorial-tools
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*
@@ -1237,9 +1237,9 @@ Test-Suite re-tutorial-tools-test
         regex                == 1.0.1.3
       , array                >= 0.4      && < 0.6
       , base                 >= 4        && < 5
-      , base-compat          >= 0.6      && < 0.10
+      , base-compat          >= 0.6      && < 0.11
       , bytestring           == 0.10.*
-      , containers           >= 0.4      && < 0.6
+      , containers           >= 0.4      && < 0.7
       , directory            >= 1.2.1.0
       , hashable             == 1.2.*
       , heredoc              >= 0.2.0.0
@@ -1252,7 +1252,7 @@ Test-Suite re-tutorial-tools-test
       , tasty                >= 0.10.1.2
       , tasty-hunit          >= 0.9.2
       , tasty-smallcheck     >= 0.8.0.1
-      , template-haskell     >= 2.7      && < 2.14
+      , template-haskell     >= 2.7      && < 2.15
       , text                 == 1.2.*
       , time                 >= 1.4.2    && < 1.9
       , time-locale-compat   == 0.1.*

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,11 +1,7 @@
-resolver: lts-6.33
+resolver: lts-6.35
 
 packages:
 - '.'
 
-extra-deps:
-  - regex-pcre-text-0.94.0.0
-
-flags: {}
-
-extra-package-dbs: []
+#extra-deps:
+#  - regex-pcre-text-0.94.0.0

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -1,8 +1,7 @@
 resolver: lts-2.22
-install-ghc: true
-flags: {}
 packages:
 - '.'
+install-ghc: true
 system-ghc: false
 extra-deps:
   - regex-pcre-text-0.94.0.0

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -1,8 +1,7 @@
-resolver: lts-8.16
-install-ghc: true
-flags: {}
+resolver: lts-8.24
 packages:
 - '.'
+install-ghc: true
 system-ghc: false
 extra-deps:
   - regex-pcre-text-0.94.0.0

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.1
+resolver: lts-11.22 # GHC 8.2.2
 packages:
 - '.'
 install-ghc: true

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-03-21
+resolver: lts-12.18 # GHC 8.4.4
 packages:
 - '.'
 install-ghc: true

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,8 +1,5 @@
-resolver: nightly-2017-06-02
-install-ghc: true
-flags: {}
+resolver: nightly-2018-11-13 # GHC 8.6.2
 packages:
 - '.'
+install-ghc: true
 system-ghc: false
-extra-deps:
-  - regex-pcre-text-0.94.0.0


### PR DESCRIPTION
With your change, the tests were failing because of the test `re-sort-imports-test`. It ensures that imports in the codebase (under directories `Data/` and `examples/`) have their imports in sorted order. Your use of `CPP` in ` examples/re-top.lhs` was preventing the simple check for sorted imports to work properly. To work around this problem, I found an alternative to using `CPP`.

I also bumped all the stack yaml files to the latest resolvers for their respective GHC versions. This involved loosening the constraints in `regex.cabal` of `base-compat` and `containers`. In particular, `stack-nightly.yaml` now uses GHC 8.6.2 and `stack-8.4.yaml` uses GHC 8.4.4.